### PR TITLE
Specify http client

### DIFF
--- a/client.go
+++ b/client.go
@@ -24,15 +24,38 @@ type Client struct {
 	// timeout is 120000, the minimum is 1000. If not specified by the client,
 	// a value halfway between maximum and minimum is used.
 	Poll uint32
+
+	httpClient *http.Client
+}
+
+// Option interface used for setting optional Client properties.
+type Option interface {
+	apply(*Client)
+}
+
+type optionFunc func(*Client)
+
+func (o optionFunc) apply(c *Client) { o(c) }
+
+// WithHttpClient specifies which http client to use.
+func WithHttpClient(httpClient *http.Client) Option {
+	return optionFunc(func(c *Client) { c.httpClient = httpClient })
 }
 
 // NewClient creates a new client instance. Poll will be in range 1000ms to
 // 120000ms.
-func NewClient(url string, poll uint32) *Client {
-	return &Client{
-		APIUrl: url,
-		Poll:   poll,
+func NewClient(url string, poll uint32, opts ...Option) *Client {
+	client := &Client{
+		APIUrl:     url,
+		Poll:       poll,
+		httpClient: &http.Client{},
 	}
+
+	for _, v := range opts {
+		v.apply(client)
+	}
+
+	return client
 }
 
 // Authenticate does authentication in asynchronous way using channel.
@@ -135,7 +158,7 @@ func (c *Client) getEndpointResponse(req *AuthRequest) (*AuthResponse, error) {
 		return nil, err
 	}
 
-	httpResp, err := makeHTTPRequest(http.MethodPost, url, payload)
+	httpResp, err := makeHTTPRequest(c.httpClient, http.MethodPost, url, payload)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +200,7 @@ func (c *Client) getSessionResponse(
 		url += fmt.Sprintf("?timeoutMs=%v", c.Poll)
 	}
 
-	httpResp, err := makeHTTPRequest(http.MethodGet, url, nil)
+	httpResp, err := makeHTTPRequest(c.httpClient, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -222,8 +245,7 @@ func getHTTPResponseBody(r *http.Response) ([]byte, error) {
 }
 
 // makeHTTPRequest makes just a HTTP request.
-func makeHTTPRequest(mthd, url string, payld []byte) (*http.Response, error) {
-	httpClient := http.Client{}
+func makeHTTPRequest(httpClient *http.Client, mthd, url string, payld []byte) (*http.Response, error) {
 	rd := bytes.NewReader(payld)
 	httpReq, err := http.NewRequest(mthd, url, rd)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -46,13 +46,16 @@ func WithHttpClient(httpClient *http.Client) Option {
 // 120000ms.
 func NewClient(url string, poll uint32, opts ...Option) *Client {
 	client := &Client{
-		APIUrl:     url,
-		Poll:       poll,
-		httpClient: &http.Client{},
+		APIUrl: url,
+		Poll:   poll,
 	}
 
 	for _, v := range opts {
 		v.apply(client)
+	}
+
+	if client.httpClient == nil {
+		client.httpClient = new(http.Client)
 	}
 
 	return client

--- a/client_test.go
+++ b/client_test.go
@@ -504,3 +504,28 @@ func TestSignExtended(t *testing.T) {
 	fmt.Println("Personal ID:", identity.SerialNumber)
 	fmt.Println("Country:", identity.Country)
 }
+
+func TestNewClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("http client set by default", func(t *testing.T) {
+		t.Parallel()
+
+		client := NewClient("https://sid.demo.sk.ee/smart-id-rp/v2/", 10000)
+
+		if client.httpClient == nil {
+			t.Error("httpClient is not set by default")
+		}
+	})
+
+	t.Run("specify http client", func(t *testing.T) {
+		t.Parallel()
+
+		httpClient := new(http.Client)
+		client := NewClient("https://sid.demo.sk.ee/smart-id-rp/v2/", 10000, WithHttpClient(httpClient))
+
+		if client.httpClient != httpClient {
+			t.Error("httpClient is not specified")
+		}
+	})
+}


### PR DESCRIPTION
Allow specifying the HTTP client to make it more flexible.

We require tracing to improve the observability of the system by using custom HTTP client. E.g. [otelhttp.DefaultClient](https://github.com/open-telemetry/opentelemetry-go-contrib/blob/instrumentation/net/http/otelhttp/v0.40.0/instrumentation/net/http/otelhttp/client.go#L28).